### PR TITLE
Add string extensions for convenient profanity filtering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,13 @@
+## [Unreleased]
+
+- Added string extension methods for convenient profanity filtering
+- New `String.hasProfanity()` method returns true if the string contains profanity
+- New `String.censor({String? replaceWith})` method returns a censored version of the string
+- New `String.getAllProfanity()` method returns a list of all profane words found
+- Extensions use a static default ProfanityFilter instance for efficiency
+- Added comprehensive test suite with 16 new tests for extension methods
+- Added example files demonstrating string extension usage
+
 ## [2.0.0] Migrated to null safety
 - Released 2.0.0 with null safety
 - Fixed issue with getAllProfanity that was incorrectly detecting substrings as profanity.

--- a/README.md
+++ b/README.md
@@ -10,6 +10,8 @@ Simple Dart class to create filters with methods to check and censor strings aga
 
 You can also use the filters to filter out a custom set of words, by using the `ProfanityFilter.filterOnly()` constructor.
 
+For convenience, String extension methods are available to check and censor strings directly without creating a filter instance.
+
 ## Usage
 
 To use this plugin, add `profanity_filter` as a [dependency in your pubspec.yaml file](https://flutter.dev/platform-plugins/).
@@ -84,6 +86,49 @@ String cleanString = filter.censor('you are an ass'); //cleanString: 'you are an
 
 Optionally, you can provide your own clean replacement word to the `replaceWith` named parameter.
 `filter.censor(string, replaceWith:'[censored]')` will replace any profanity in `string` with `[censored]`
+
+## String Extensions
+
+For convenience, you can use String extension methods to check and censor strings directly without creating a filter instance. These extensions use the default profanity list.
+
+To use the extensions, make sure to import the package:
+
+```dart
+import 'package:profanity_filter/profanity_filter.dart';
+```
+
+### `hasProfanity()` - Check if string contains profanity
+
+Call the `hasProfanity()` method directly on a string.
+
+#### Example
+
+```dart
+bool hasBadWords = 'hello bitches'.hasProfanity(); // true
+bool isClean = 'hello friends'.hasProfanity(); // false
+```
+
+### `censor()` - Censor a string
+
+Call the `censor()` method directly on a string to get a censored version.
+
+#### Example
+
+```dart
+String clean = 'you are an ass'.censor(); // 'you are an ***'
+String custom = 'you are an ass'.censor(replaceWith: '[censored]'); // 'you are an [censored]'
+```
+
+### `getAllProfanity()` - Get list of profane words
+
+Call the `getAllProfanity()` method directly on a string to get a list of profane words found.
+
+#### Example
+
+```dart
+List<String> words = 'what the fuck'.getAllProfanity(); // ['fuck']
+List<String> noWords = 'what the fish'.getAllProfanity(); // []
+```
 
 ## Default Profanity List
 

--- a/example/issue_example.dart
+++ b/example/issue_example.dart
@@ -1,0 +1,36 @@
+import 'package:profanity_filter/profanity_filter.dart';
+
+/// This example demonstrates the exact syntax requested in the issue.
+void main() {
+  print('=== Testing exact syntax from the issue ===\n');
+
+  // Test the exact examples from the problem statement
+  print('Test 1: hasProfanity()');
+  bool result1 = 'The sample string'.hasProfanity();
+  print('  \'The sample string\'.hasProfanity() = $result1');
+  assert(result1 == false, 'Clean string should not have profanity');
+
+  bool result2 = 'what the fuck'.hasProfanity();
+  print('  \'what the fuck\'.hasProfanity() = $result2');
+  assert(result2 == true, 'String with profanity should return true');
+
+  print('\nTest 2: censor()');
+  String result3 = 'The sample string'.censor();
+  print('  \'The sample string\'.censor() = "$result3"');
+  assert(result3 == 'The sample string', 'Clean string should not be censored');
+
+  String result4 = 'what the fuck'.censor();
+  print('  \'what the fuck\'.censor() = "$result4"');
+  assert(result4 == 'what the ****', 'Profanity should be censored');
+
+  print('\nTest 3: getAllProfanity()');
+  List<String> result5 = 'The sample string'.getAllProfanity();
+  print('  \'The sample string\'.getAllProfanity() = $result5');
+  assert(result5.isEmpty, 'Clean string should return empty list');
+
+  List<String> result6 = 'what the fuck'.getAllProfanity();
+  print('  \'what the fuck\'.getAllProfanity() = $result6');
+  assert(result6.isNotEmpty, 'String with profanity should return non-empty list');
+
+  print('\n✅ All assertions passed! The API works exactly as specified.');
+}

--- a/example/string_extension_example.dart
+++ b/example/string_extension_example.dart
@@ -1,0 +1,37 @@
+import 'package:profanity_filter/profanity_filter.dart';
+
+void main() {
+  print('=== String Extension Examples ===\n');
+
+  // Example 1: hasProfanity()
+  print('Example 1: hasProfanity()');
+  String example1 = 'The sample string';
+  String example2 = 'what the fuck';
+  print('  "$example1".hasProfanity() = ${example1.hasProfanity()}');
+  print('  "$example2".hasProfanity() = ${example2.hasProfanity()}');
+  print('');
+
+  // Example 2: censor()
+  print('Example 2: censor()');
+  String example3 = 'you are an ass';
+  print('  "$example3".censor() = "${example3.censor()}"');
+  print(
+      '  "$example3".censor(replaceWith: "[censored]") = "${example3.censor(replaceWith: "[censored]")}"');
+  print('');
+
+  // Example 3: getAllProfanity()
+  print('Example 3: getAllProfanity()');
+  String example4 = 'what the fuck pass';
+  String example5 = 'hello friends';
+  print('  "$example4".getAllProfanity() = ${example4.getAllProfanity()}');
+  print('  "$example5".getAllProfanity() = ${example5.getAllProfanity()}');
+  print('');
+
+  // Example 4: Chaining operations
+  print('Example 4: Chaining operations on the same string');
+  String testString = 'hello bitches and friends';
+  print('  Original: "$testString"');
+  print('  Has profanity: ${testString.hasProfanity()}');
+  print('  Censored: "${testString.censor()}"');
+  print('  Found words: ${testString.getAllProfanity()}');
+}

--- a/lib/profanity_filter.dart
+++ b/lib/profanity_filter.dart
@@ -2,6 +2,8 @@ library profanity_filter;
 
 import './default_list.dart';
 
+export 'profanity_filter_extension.dart';
+
 ///Filter that lets you check and censor strings with profanity.
 ///
 ///Create an instance with the default constructor to use the default list of

--- a/lib/profanity_filter_extension.dart
+++ b/lib/profanity_filter_extension.dart
@@ -1,0 +1,48 @@
+import 'profanity_filter.dart';
+
+/// Extension methods on [String] for profanity filtering.
+///
+/// These extensions provide convenient methods to check, censor, and find
+/// profanity in strings using the default [ProfanityFilter].
+extension ProfanityFilterExtension on String {
+  static final ProfanityFilter _defaultFilter = ProfanityFilter();
+
+  /// Returns `true` if this string contains profanity, false otherwise.
+  ///
+  /// Uses the default profanity list from LDNOOBW.
+  ///
+  /// Example:
+  /// ```dart
+  /// bool hasBadWords = 'hello bitches'.hasProfanity(); // true
+  /// bool isClean = 'hello friends'.hasProfanity(); // false
+  /// ```
+  bool hasProfanity() {
+    return _defaultFilter.hasProfanity(this);
+  }
+
+  /// Returns a censored version of this string, with asterisk (*) pattern
+  /// as default.
+  ///
+  /// If [replaceWith] is provided, replaces all profane words with that
+  /// [replaceWith] string.
+  ///
+  /// Example:
+  /// ```dart
+  /// String clean = 'you are an ass'.censor(); // 'you are an ***'
+  /// String custom = 'you are an ass'.censor(replaceWith: '[censored]'); // 'you are an [censored]'
+  /// ```
+  String censor({String? replaceWith}) {
+    return _defaultFilter.censor(this, replaceWith: replaceWith);
+  }
+
+  /// Returns a list of all profanity found in this string.
+  ///
+  /// Example:
+  /// ```dart
+  /// List<String> words = 'what the fuck'.getAllProfanity(); // ['fuck']
+  /// List<String> noWords = 'what the fish'.getAllProfanity(); // []
+  /// ```
+  List<String> getAllProfanity() {
+    return _defaultFilter.getAllProfanity(this);
+  }
+}

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -5,330 +5,385 @@ packages:
     dependency: transitive
     description:
       name: _fe_analyzer_shared
-      url: "https://pub.dartlang.org"
+      sha256: "0b2f2bd91ba804e53a61d757b986f89f1f9eaed5b11e4b2f5a2468d86d6c9fc7"
+      url: "https://pub.dev"
     source: hosted
-    version: "14.0.0"
+    version: "67.0.0"
   analyzer:
     dependency: transitive
     description:
       name: analyzer
-      url: "https://pub.dartlang.org"
+      sha256: "37577842a27e4338429a1cbc32679d508836510b056f1eedf0c8d20e39c1383d"
+      url: "https://pub.dev"
     source: hosted
-    version: "0.41.2"
+    version: "6.4.1"
   args:
     dependency: transitive
     description:
       name: args
-      url: "https://pub.dartlang.org"
+      sha256: "37a4264b0b7fb930e94c0c47558f3b6c4f4e9cb7e655a3ea373131d79b2dc0cc"
+      url: "https://pub.dev"
     source: hosted
     version: "2.0.0"
   async:
     dependency: transitive
     description:
       name: async
-      url: "https://pub.dartlang.org"
+      sha256: "758e6d74e971c3e5aceb4110bfd6698efc7f501675bcfe0c775459a8140750eb"
+      url: "https://pub.dev"
     source: hosted
-    version: "2.5.0"
+    version: "2.13.0"
   boolean_selector:
     dependency: transitive
     description:
       name: boolean_selector
-      url: "https://pub.dartlang.org"
+      sha256: "5bbf32bc9e518d41ec49718e2931cd4527292c9b0c6d2dffcf7fe6b9a8a8cf72"
+      url: "https://pub.dev"
     source: hosted
     version: "2.1.0"
   charcode:
     dependency: transitive
     description:
       name: charcode
-      url: "https://pub.dartlang.org"
+      sha256: "8e36feea6de5ea69f2199f29cf42a450a855738c498b57c0b980e2d3cca9c362"
+      url: "https://pub.dev"
     source: hosted
     version: "1.2.0"
-  cli_util:
-    dependency: transitive
-    description:
-      name: cli_util
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "0.3.0"
   collection:
     dependency: transitive
     description:
       name: collection
-      url: "https://pub.dartlang.org"
+      sha256: "2f5709ae4d3d59dd8f7cd309b4e023046b57d8a6c82130785d2b0e5868084e76"
+      url: "https://pub.dev"
     source: hosted
-    version: "1.15.0"
+    version: "1.19.1"
   convert:
     dependency: transitive
     description:
       name: convert
-      url: "https://pub.dartlang.org"
+      sha256: df567b950053d83b4dba3e8c5799c411895d146f82b2147114b666a4fd9a80dd
+      url: "https://pub.dev"
     source: hosted
     version: "3.0.0"
   coverage:
     dependency: transitive
     description:
       name: coverage
-      url: "https://pub.dartlang.org"
+      sha256: "3945034e86ea203af7a056d98e98e42a5518fff200d6e8e6647e1886b07e936e"
+      url: "https://pub.dev"
     source: hosted
-    version: "0.15.2"
+    version: "1.8.0"
   crypto:
     dependency: transitive
     description:
       name: crypto
-      url: "https://pub.dartlang.org"
+      sha256: "8be10341257b613566fdc9fd073c46f7c032ed329b1c732bda17aca29f2366c8"
+      url: "https://pub.dev"
     source: hosted
     version: "3.0.0"
   file:
     dependency: transitive
     description:
       name: file
-      url: "https://pub.dartlang.org"
+      sha256: "716a02ed2fabe2d0cc0fa0bcaefae83c412e8aef6c559aa394ed7c12ec5b981b"
+      url: "https://pub.dev"
     source: hosted
     version: "6.0.0"
+  frontend_server_client:
+    dependency: transitive
+    description:
+      name: frontend_server_client
+      sha256: f64a0333a82f30b0cca061bc3d143813a486dc086b574bfb233b7c1372427694
+      url: "https://pub.dev"
+    source: hosted
+    version: "4.0.0"
   glob:
     dependency: transitive
     description:
       name: glob
-      url: "https://pub.dartlang.org"
+      sha256: "36a6ea2cac1f93742ecee02250fb498122c0993eb948120ff0dbef6cd694beb8"
+      url: "https://pub.dev"
     source: hosted
     version: "2.0.0"
   http_multi_server:
     dependency: transitive
     description:
       name: http_multi_server
-      url: "https://pub.dartlang.org"
+      sha256: aa6199f908078bb1c5efb8d8638d4ae191aac11b311132c3ef48ce352fb52ef8
+      url: "https://pub.dev"
     source: hosted
-    version: "2.2.0"
+    version: "3.2.2"
   http_parser:
     dependency: transitive
     description:
       name: http_parser
-      url: "https://pub.dartlang.org"
+      sha256: e362d639ba3bc07d5a71faebb98cde68c05bfbcfbbb444b60b6f60bb67719185
+      url: "https://pub.dev"
     source: hosted
     version: "4.0.0"
   io:
     dependency: transitive
     description:
       name: io
-      url: "https://pub.dartlang.org"
+      sha256: dfd5a80599cf0165756e3181807ed3e77daf6dd4137caaad72d0b7931597650b
+      url: "https://pub.dev"
     source: hosted
-    version: "0.3.4"
+    version: "1.0.5"
   js:
     dependency: transitive
     description:
       name: js
-      url: "https://pub.dartlang.org"
+      sha256: "53385261521cc4a0c4658fd0ad07a7d14591cf8fc33abbceae306ddb974888dc"
+      url: "https://pub.dev"
     source: hosted
-    version: "0.6.3"
+    version: "0.7.2"
   logging:
     dependency: transitive
     description:
       name: logging
-      url: "https://pub.dartlang.org"
+      sha256: "3730d4c02b0c2d1db80ef9904e27fa796d75474f572a70011e0e616ee6bfc0ff"
+      url: "https://pub.dev"
     source: hosted
     version: "1.0.0"
   matcher:
     dependency: transitive
     description:
       name: matcher
-      url: "https://pub.dartlang.org"
+      sha256: dc58c723c3c24bf8d3e2d3ad3f2f9d7bd9cf43ec6feaa64181775e60190153f2
+      url: "https://pub.dev"
     source: hosted
-    version: "0.12.10"
+    version: "0.12.17"
   meta:
     dependency: transitive
     description:
       name: meta
-      url: "https://pub.dartlang.org"
+      sha256: "23f08335362185a5ea2ad3a4e597f1375e78bce8a040df5c600c8d3552ef2394"
+      url: "https://pub.dev"
     source: hosted
-    version: "1.3.0"
+    version: "1.17.0"
   mime:
     dependency: transitive
     description:
       name: mime
-      url: "https://pub.dartlang.org"
+      sha256: a7a98ea7f366e2cc9d2b20873815aebec5e2bc124fe0da9d3f7f59b0625ea180
+      url: "https://pub.dev"
     source: hosted
     version: "1.0.0"
   node_preamble:
     dependency: transitive
     description:
       name: node_preamble
-      url: "https://pub.dartlang.org"
+      sha256: "6e7eac89047ab8a8d26cf16127b5ed26de65209847630400f9aefd7cd5c730db"
+      url: "https://pub.dev"
     source: hosted
-    version: "1.4.13"
+    version: "2.0.2"
   package_config:
     dependency: transitive
     description:
       name: package_config
-      url: "https://pub.dartlang.org"
+      sha256: f096c55ebb7deb7e384101542bfba8c52696c1b56fca2eb62827989ef2353bbc
+      url: "https://pub.dev"
     source: hosted
-    version: "1.9.3"
+    version: "2.2.0"
   path:
     dependency: transitive
     description:
       name: path
-      url: "https://pub.dartlang.org"
+      sha256: "2ad4cddff7f5cc0e2d13069f2a3f7a73ca18f66abd6f5ecf215219cdb3638edb"
+      url: "https://pub.dev"
     source: hosted
     version: "1.8.0"
   pedantic:
     dependency: transitive
     description:
       name: pedantic
-      url: "https://pub.dartlang.org"
+      sha256: "207f9260c7a46946d09619b5ba1caf1fd50faf10fe3bae0176c626dceac5193d"
+      url: "https://pub.dev"
     source: hosted
     version: "1.10.0"
   pool:
     dependency: transitive
     description:
       name: pool
-      url: "https://pub.dartlang.org"
+      sha256: "05955e3de2683e1746222efd14b775df7131139e07695dc8e24650f6b4204504"
+      url: "https://pub.dev"
     source: hosted
     version: "1.5.0"
   pub_semver:
     dependency: transitive
     description:
       name: pub_semver
-      url: "https://pub.dartlang.org"
+      sha256: "5bfcf68ca79ef689f8990d1160781b4bad40a3bd5e5218ad4076ddb7f4081585"
+      url: "https://pub.dev"
     source: hosted
-    version: "2.0.0"
+    version: "2.2.0"
   shelf:
     dependency: transitive
     description:
       name: shelf
-      url: "https://pub.dartlang.org"
+      sha256: c0710a5ca61f1a96e9aae37081040f537c1b96265040edeb70c8817a10d361c6
+      url: "https://pub.dev"
     source: hosted
     version: "1.0.0"
   shelf_packages_handler:
     dependency: transitive
     description:
       name: shelf_packages_handler
-      url: "https://pub.dartlang.org"
+      sha256: "89f967eca29607c933ba9571d838be31d67f53f6e4ee15147d5dc2934fee1b1e"
+      url: "https://pub.dev"
     source: hosted
-    version: "2.0.1"
+    version: "3.0.2"
   shelf_static:
     dependency: transitive
     description:
       name: shelf_static
-      url: "https://pub.dartlang.org"
+      sha256: "8584c0aa0f5756a61519b1a2fc2cd22ddbc518e9396bd33ebf06b9836bb23d13"
+      url: "https://pub.dev"
     source: hosted
-    version: "0.2.9+2"
+    version: "1.0.0"
   shelf_web_socket:
     dependency: transitive
     description:
       name: shelf_web_socket
-      url: "https://pub.dartlang.org"
+      sha256: "520368a1a49798425310ca0ee28eb92b3c737e4e9d173c31b6c66fe090ebc6fc"
+      url: "https://pub.dev"
     source: hosted
-    version: "0.2.4"
+    version: "1.0.0"
   source_map_stack_trace:
     dependency: transitive
     description:
       name: source_map_stack_trace
-      url: "https://pub.dartlang.org"
+      sha256: "8c463326277f68a628abab20580047b419c2ff66756fd0affd451f73f9508c11"
+      url: "https://pub.dev"
     source: hosted
     version: "2.1.0"
   source_maps:
     dependency: transitive
     description:
       name: source_maps
-      url: "https://pub.dartlang.org"
+      sha256: "52de2200bb098de739794c82d09c41ac27b2e42fd7e23cce7b9c74bf653c7296"
+      url: "https://pub.dev"
     source: hosted
     version: "0.10.10"
   source_span:
     dependency: transitive
     description:
       name: source_span
-      url: "https://pub.dartlang.org"
+      sha256: d5f89a9e52b36240a80282b3dc0667dd36e53459717bb17b8fb102d30496606a
+      url: "https://pub.dev"
     source: hosted
     version: "1.8.1"
   stack_trace:
     dependency: transitive
     description:
       name: stack_trace
-      url: "https://pub.dartlang.org"
+      sha256: f8d9f247e2f9f90e32d1495ff32dac7e4ae34ffa7194c5ff8fcc0fd0e52df774
+      url: "https://pub.dev"
     source: hosted
     version: "1.10.0"
   stream_channel:
     dependency: transitive
     description:
       name: stream_channel
-      url: "https://pub.dartlang.org"
+      sha256: db47e4797198ee601990820437179bb90219f918962318d494ada2b4b11e6f6d
+      url: "https://pub.dev"
     source: hosted
     version: "2.1.0"
   string_scanner:
     dependency: transitive
     description:
       name: string_scanner
-      url: "https://pub.dartlang.org"
+      sha256: dd11571b8a03f7cadcf91ec26a77e02bfbd6bbba2a512924d3116646b4198fc4
+      url: "https://pub.dev"
     source: hosted
     version: "1.1.0"
   term_glyph:
     dependency: transitive
     description:
       name: term_glyph
-      url: "https://pub.dartlang.org"
+      sha256: a88162591b02c1f3a3db3af8ce1ea2b374bd75a7bb8d5e353bcfbdc79d719830
+      url: "https://pub.dev"
     source: hosted
     version: "1.2.0"
   test:
     dependency: "direct dev"
     description:
       name: test
-      url: "https://pub.dartlang.org"
+      sha256: "75906bf273541b676716d1ca7627a17e4c4070a3a16272b7a3dc7da3b9f3f6b7"
+      url: "https://pub.dev"
     source: hosted
-    version: "1.16.0"
+    version: "1.26.3"
   test_api:
     dependency: transitive
     description:
       name: test_api
-      url: "https://pub.dartlang.org"
+      sha256: ab2726c1a94d3176a45960b6234466ec367179b87dd74f1611adb1f3b5fb9d55
+      url: "https://pub.dev"
     source: hosted
-    version: "0.2.19"
+    version: "0.7.7"
   test_core:
     dependency: transitive
     description:
       name: test_core
-      url: "https://pub.dartlang.org"
+      sha256: "0cc24b5ff94b38d2ae73e1eb43cc302b77964fbf67abad1e296025b78deb53d0"
+      url: "https://pub.dev"
     source: hosted
-    version: "0.3.12"
+    version: "0.6.12"
   typed_data:
     dependency: transitive
     description:
       name: typed_data
-      url: "https://pub.dartlang.org"
+      sha256: "53bdf7e979cfbf3e28987552fd72f637e63f3c8724c9e56d9246942dc2fa36ee"
+      url: "https://pub.dev"
     source: hosted
     version: "1.3.0"
   vm_service:
     dependency: transitive
     description:
       name: vm_service
-      url: "https://pub.dartlang.org"
+      sha256: "0968250880a6c5fe7edc067ed0a13d4bae1577fe2771dcf3010d52c4a9d3ca14"
+      url: "https://pub.dev"
     source: hosted
-    version: "6.0.1"
+    version: "14.3.1"
   watcher:
     dependency: transitive
     description:
       name: watcher
-      url: "https://pub.dartlang.org"
+      sha256: "592ab6e2892f67760543fb712ff0177f4ec76c031f02f5b4ff8d3fc5eb9fb61a"
+      url: "https://pub.dev"
     source: hosted
-    version: "1.0.0"
+    version: "1.1.4"
+  web:
+    dependency: transitive
+    description:
+      name: web
+      sha256: "97da13628db363c635202ad97068d47c5b8aa555808e7a9411963c533b449b27"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.5.1"
   web_socket_channel:
     dependency: transitive
     description:
       name: web_socket_channel
-      url: "https://pub.dartlang.org"
+      sha256: "58c6666b342a38816b2e7e50ed0f1e261959630becd4c879c4f26bfa14aa5a42"
+      url: "https://pub.dev"
     source: hosted
-    version: "1.2.0"
+    version: "2.4.5"
   webkit_inspection_protocol:
     dependency: transitive
     description:
       name: webkit_inspection_protocol
-      url: "https://pub.dartlang.org"
+      sha256: "87d3f2333bb240704cd3f1c6b5b7acd8a10e7f0bc28c28dcf14e782014f4a572"
+      url: "https://pub.dev"
     source: hosted
-    version: "0.7.5"
+    version: "1.2.1"
   yaml:
     dependency: transitive
     description:
       name: yaml
-      url: "https://pub.dartlang.org"
+      sha256: "252eb4c4d54f384c9fee16795f3d7381b037c53261aa1772dc43b71133581e41"
+      url: "https://pub.dev"
     source: hosted
     version: "3.0.0"
 sdks:
-  dart: ">=2.12.0 <3.0.0"
+  dart: ">=3.7.0-0 <4.0.0"

--- a/test/profanity_filter_extension_test.dart
+++ b/test/profanity_filter_extension_test.dart
@@ -1,0 +1,112 @@
+import 'package:test/test.dart';
+import '../lib/profanity_filter.dart';
+
+void main() {
+  group('String Extension - hasProfanity', () {
+    test('detects profanity in string', () {
+      expect('hello bitches'.hasProfanity(), true);
+      expect('you are an ass'.hasProfanity(), true);
+      expect('what the fuck'.hasProfanity(), true);
+    });
+
+    test('returns false for clean strings', () {
+      expect('hello friends'.hasProfanity(), false);
+      expect('what the fish'.hasProfanity(), false);
+      expect('have a nice day'.hasProfanity(), false);
+    });
+
+    test('is case-insensitive', () {
+      expect('hello BITCHES'.hasProfanity(), true);
+      expect('WHAT THE FUCK'.hasProfanity(), true);
+      expect('You Are An AsS'.hasProfanity(), true);
+    });
+
+    test('does not detect substring as profanity', () {
+      expect('practitioner assessment'.hasProfanity(), false);
+    });
+  });
+
+  group('String Extension - censor', () {
+    test('censors profanity with asterisks by default', () {
+      expect('what the fuck'.censor(), 'what the ****');
+      expect('you are an ass'.censor(), 'you are an ***');
+      expect('hello bitches'.censor(), 'hello *******');
+    });
+
+    test('censors with case preservation', () {
+      expect('what the FucK pass'.censor(), 'what the **** pass');
+      expect('WHAT THE FUCK'.censor(), 'WHAT THE ****');
+    });
+
+    test('censors with custom replaceWith parameter', () {
+      expect('what the fuck'.censor(replaceWith: '[censored]'),
+          'what the [censored]');
+      expect('you are an ass'.censor(replaceWith: '[BLEEP]'),
+          'you are an [BLEEP]');
+    });
+
+    test('does not censor clean strings', () {
+      expect('what the fish'.censor(), 'what the fish');
+      expect('hello friends'.censor(), 'hello friends');
+    });
+
+    test('does not censor substring as profanity', () {
+      expect('practitioner assessment'.censor(), 'practitioner assessment');
+    });
+  });
+
+  group('String Extension - getAllProfanity', () {
+    test('returns list of profanity found', () {
+      expect('what the fuck'.getAllProfanity(), ['fuck']);
+      expect('you are an ass'.getAllProfanity(), ['ass']);
+      expect('hello bitches'.getAllProfanity(), ['bitches']);
+    });
+
+    test('returns empty list for clean strings', () {
+      expect('what the fish'.getAllProfanity(), []);
+      expect('hello friends'.getAllProfanity(), []);
+      expect('have a nice day'.getAllProfanity(), []);
+    });
+
+    test('returns multiple profane words if present', () {
+      // Note: This depends on the actual word list
+      String multiProfanity = 'fuck ass';
+      List<String> found = multiProfanity.getAllProfanity();
+      expect(found.length, greaterThan(0));
+    });
+
+    test('does not detect substring as profanity', () {
+      expect('practitioner assessment'.getAllProfanity(), []);
+    });
+  });
+
+  group('String Extension - Integration tests', () {
+    test('works with empty strings', () {
+      expect(''.hasProfanity(), false);
+      expect(''.censor(), '');
+      expect(''.getAllProfanity(), []);
+    });
+
+    test('works with single word strings', () {
+      expect('fuck'.hasProfanity(), true);
+      expect('fuck'.censor(), '****');
+      expect('fuck'.getAllProfanity(), ['fuck']);
+
+      expect('hello'.hasProfanity(), false);
+      expect('hello'.censor(), 'hello');
+      expect('hello'.getAllProfanity(), []);
+    });
+
+    test('chain of operations produces consistent results', () {
+      String testString = 'what the fuck pass';
+
+      bool hasProfanityResult = testString.hasProfanity();
+      String censorResult = testString.censor();
+      List<String> allProfanityResult = testString.getAllProfanity();
+
+      expect(hasProfanityResult, true);
+      expect(censorResult, 'what the **** pass');
+      expect(allProfanityResult, ['fuck']);
+    });
+  });
+}


### PR DESCRIPTION
### Add string extensions for convenient profanity filtering

- Added string extension methods for convenient profanity filtering
- New `String.hasProfanity()` method returns true if the string contains profanity
- New `String.censor({String? replaceWith})` method returns a censored version of the string
- New `String.getAllProfanity()` method returns a list of all profane words found
- Extensions use a static default ProfanityFilter instance for efficiency
- Added comprehensive test suite with 16 new tests for extension methods
- Added example files demonstrating string extension usage